### PR TITLE
AST-3305 - Fix:Display ruleset not working as expected on singular post/tag/page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Other plugins we found are heavy with ugly interface, non supported, developed o
 
 ## Changelog ##
 
+### 1.1.8 ###
+- Fix: Sidebar rendering issue where specifying "All Singulars from {{category}}" resulted in incorrect display of "{{category}} - Category" after saving.
+
 ### 1.1.7 ###
 - Fix: Added compatibility with WordPress v5.7 for jQuery migration warnings on admin page.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** custom sidebar, sidebar manager, custom widget areas, widgets, conditional sidebar
 **Requires at least:** 4.0
 **Tested up to:** 6.2
-**Stable tag:** 1.1.7
+**Stable tag:** 1.1.8
 **License:** GPLv2 or later
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
+++ b/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
@@ -682,7 +682,6 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 						// taxonomy options.
 						if ( strpos( $sel_value, 'tax-' ) !== false ) {
 						
-						
 							$suffix = "";
 						
 							$term_suffix = "";
@@ -695,9 +694,7 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 						
 							}
 						
-						
-						
-							$tax_id = (int) str_replace( 'tax-', '', $sel_value ); // THIS BIT HERE WOULD CHOP OFF TEXT AFTER THE TERM-ID
+							$tax_id = (int) str_replace( 'tax-', '', $sel_value );
 						
 							$term = get_term( $tax_id );
 						

--- a/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
+++ b/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
@@ -692,7 +692,7 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 							$term          = get_term( $tax_id );
 							$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
 							$output       .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected">' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
-						}			
+						}
 					}
 				}
 				$output .= '</select>';

--- a/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
+++ b/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
@@ -681,11 +681,32 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 
 						// taxonomy options.
 						if ( strpos( $sel_value, 'tax-' ) !== false ) {
-							$tax_id        = (int) str_replace( 'tax-', '', $sel_value );
-							$term          = get_term( $tax_id );
-							$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
-							$output       .= '<option value="tax-' . $tax_id . '" selected="selected" >' . $term->name . ' - ' . $term_taxonomy . '</option>';
-
+						
+						
+						$suffix = "";
+						
+						$term_suffix = "";
+						
+						if (preg_match("/\d+(-single-.+)$/", $sel_value, $m)) {
+						
+						$suffix = $m[1];
+						
+						$term_suffix = " (Singulars)";
+						
+						}
+						
+						
+						
+						$tax_id = (int) str_replace( 'tax-', '', $sel_value ); // THIS BIT HERE WOULD CHOP OFF TEXT AFTER THE TERM-ID
+						
+						$term = get_term( $tax_id );
+						
+						$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
+						
+						$output .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected" >' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
+						
+						
+						
 						}
 					}
 				}

--- a/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
+++ b/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
@@ -691,8 +691,8 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 							$tax_id = (int) str_replace( 'tax-', '', $sel_value );
 							$term = get_term( $tax_id );
 							$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
-							$output .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected" >' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
-						}
+							$output .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected">' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
+						}						
 					}
 				}
 				$output .= '</select>';

--- a/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
+++ b/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
@@ -683,27 +683,27 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 						if ( strpos( $sel_value, 'tax-' ) !== false ) {
 						
 						
-						$suffix = "";
+							$suffix = "";
 						
-						$term_suffix = "";
+							$term_suffix = "";
 						
-						if (preg_match("/\d+(-single-.+)$/", $sel_value, $m)) {
+							if (preg_match("/\d+(-single-.+)$/", $sel_value, $m)) {
 						
-						$suffix = $m[1];
+								$suffix = $m[1];
 						
-						$term_suffix = " (Singulars)";
+								$term_suffix = " (Singulars)";
 						
-						}
+							}
 						
 						
 						
-						$tax_id = (int) str_replace( 'tax-', '', $sel_value ); // THIS BIT HERE WOULD CHOP OFF TEXT AFTER THE TERM-ID
+							$tax_id = (int) str_replace( 'tax-', '', $sel_value ); // THIS BIT HERE WOULD CHOP OFF TEXT AFTER THE TERM-ID
 						
-						$term = get_term( $tax_id );
+							$term = get_term( $tax_id );
 						
-						$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
+							$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
 						
-						$output .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected" >' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
+							$output .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected" >' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
 						
 						
 						

--- a/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
+++ b/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
@@ -681,29 +681,17 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 
 						// taxonomy options.
 						if ( strpos( $sel_value, 'tax-' ) !== false ) {
-						
-							$suffix = "";
-						
-							$term_suffix = "";
-						
-							if (preg_match("/\d+(-single-.+)$/", $sel_value, $m)) {
-						
+							$suffix = '';
+							$term_suffix = '';
+							if ( preg_match( '/\d+(-single-.+)$/', $sel_value, $m ) ) {
 								$suffix = $m[1];
-						
-								$term_suffix = " (Singulars)";
-						
+								$term_suffix = ' (Singulars)';
 							}
 						
 							$tax_id = (int) str_replace( 'tax-', '', $sel_value );
-						
 							$term = get_term( $tax_id );
-						
 							$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
-						
 							$output .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected" >' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
-						
-						
-						
 						}
 					}
 				}

--- a/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
+++ b/classes/modules/target-rule/class-bsf-sb-target-rules-fields.php
@@ -681,18 +681,18 @@ if ( ! class_exists( 'BSF_SB_Target_Rules_Fields' ) ) {
 
 						// taxonomy options.
 						if ( strpos( $sel_value, 'tax-' ) !== false ) {
-							$suffix = '';
+							$suffix      = '';
 							$term_suffix = '';
 							if ( preg_match( '/\d+(-single-.+)$/', $sel_value, $m ) ) {
-								$suffix = $m[1];
+								$suffix      = $m[1];
 								$term_suffix = ' (Singulars)';
 							}
-						
-							$tax_id = (int) str_replace( 'tax-', '', $sel_value );
-							$term = get_term( $tax_id );
+
+							$tax_id        = (int) str_replace( 'tax-', '', $sel_value );
+							$term          = get_term( $tax_id );
 							$term_taxonomy = ucfirst( str_replace( '_', ' ', $term->taxonomy ) );
-							$output .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected">' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
-						}						
+							$output       .= '<option value="tax-' . $tax_id . $suffix . '" selected="selected">' . $term->name . ' - ' . $term_taxonomy . $term_suffix . '</option>';
+						}			
 					}
 				}
 				$output .= '</select>';

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
                 "sh bin/block-commits-with-merge-conflict.sh"
             ]
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sidebar-manager",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidebar-manager",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "main": "Gruntfile.js",
   "author": "Brainstorm Force",
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -49,7 +49,11 @@ Other plugins we found are heavy with ugly interface, non supported, developed o
 1. Add Content to the newly created sidebar.
 
 
+
 == Changelog ==
+
+= 1.1.8 =
+- Fix: Sidebar rendering issue where specifying "All Singulars from {{category}}" resulted in incorrect display of "{{category}} - Category" after saving.
 
 = 1.1.7 =
 - Fix: Added compatibility with WordPress v5.7 for jQuery migration warnings on admin page.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.me/BrainstormForce
 Tags: custom sidebar, sidebar manager, custom widget areas, widgets, conditional sidebar
 Requires at least: 4.0
 Tested up to: 6.2
-Stable tag: 1.1.7
+Stable tag: 1.1.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/sidebar-manager.php
+++ b/sidebar-manager.php
@@ -3,7 +3,7 @@
  * Plugin Name:     Sidebar Manager
  * Plugin URI:      http://www.brainstormforce.com
  * Description:     This is the plugin to create custom siderbars to your site.
- * Version:         1.1.7
+ * Version:         1.1.8
  * Author:          Brainstorm Force
  * Author URI:      https://www.brainstormforce.com/
  * Text Domain:     bsfsidebars
@@ -25,7 +25,7 @@ define( 'BSF_SB_FILE', __FILE__ );
 define( 'BSF_SB_BASE', plugin_basename( BSF_SB_FILE ) );
 define( 'BSF_SB_DIR', plugin_dir_path( BSF_SB_FILE ) );
 define( 'BSF_SB_URL', plugins_url( '/', BSF_SB_FILE ) );
-define( 'BSF_SB_VER', '1.1.7' );
+define( 'BSF_SB_VER', '1.1.8' );
 define( 'BSF_SB_PREFIX', 'bsf-sb' );
 define( 'BSF_SB_POST_TYPE', 'bsf-sidebar' );
 


### PR DESCRIPTION
**Description** - Display rules not working as excepted in the sidebar manager plugin. 

**Steps To Reproduce:** 

1. I created a Category named "AAA" and assigned the post titled "Hello World" to the "AAA" category.
2. Additionally, I assigned a test sidebar to be displayed for all singular posts from the "AAA" category.
3. As a result, the test sidebar should be visible on the URL  .
4. However, when I revisit the editing page for the "Test Sidebar" and simply click "Update," the following issues occur:
5. The test sidebar appears differently than intended.
6. On the front end of the website, the "Test Sidebar" disappears completely.
7. It is worth noting that the "Display On" setting is being saved as "tax-2" instead of "tax-2-single-category."

**Threads**

1. https://wordpress.org/support/topic/all-singulars-from-category-turn-into-category-category/page/2/
2. https://wordpress.org/support/topic/all-singulars-from-category-turn-into-category-category-2/
